### PR TITLE
fix: Unblock rake from v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp/
 .ruby-gemset
 .bundle/*
 *.gem
+.idea/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,17 @@
 # Sneakers Change Log
 
+## v2.13.0
+
+Remove rack dependency from v12.
+
+## Blinkist Fork @ v2.12.0
+
+Sneakers was blocked at v2.12.0, but that depends on rake to be ~> 12. We have some services (ex: web) running on rake v13, so that causes web to be unable to upgrade Blinkist-bus as it's conflicting with rake v13.
+
+Sneakers seems not to be maintained anymore, and this rake version limit is not being address properly so far. 
+
+More discussion [here](https://github.com/jondot/sneakers/issues/452#issuecomment-878301702) and in other issues in the same repo.
+
 ## Changes Between 2.10.0 and 2.11.0
 
 This releases includes bug fixes, support for more queue-binding options, better

--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "2.12.0"
+  VERSION = "2.13.0"
 end

--- a/lib/sneakers/version.rb
+++ b/lib/sneakers/version.rb
@@ -1,3 +1,3 @@
 module Sneakers
-  VERSION = "2.13.0"
+  VERSION = "2.12.0patch1"
 end

--- a/sneakers.gemspec
+++ b/sneakers.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bunny', '~> 2.14'
   gem.add_dependency 'concurrent-ruby', '~> 1.0'
   gem.add_dependency 'thor'
-  gem.add_dependency 'rake', '~> 12.3'
+  gem.add_dependency 'rake', '>= 12.3'
 
   # for integration environment (see .travis.yml and integration_spec)
   gem.add_development_dependency 'rabbitmq_http_api_client'
   gem.add_development_dependency 'redis'
 
-  gem.add_development_dependency 'rake', '~> 12.3'
+  gem.add_development_dependency 'rake', '>= 12.3'
   gem.add_development_dependency 'minitest', '~> 5.11'
   gem.add_development_dependency 'rr', '~> 1.2.1'
   gem.add_development_dependency 'unparser', '0.2.2' # keep below 0.2.5 for ruby 2.0 compat.


### PR DESCRIPTION
Sneakers is currently blocked at v2.12.0, but that [depends on rake to be ~> 12](https://github.com/jondot/sneakers/blob/v2.12.0/sneakers.gemspec#L36). We have some services (ex: web) running on rake v13, so that causes web to be unable to upgrade Blinkist-bus as it's conflicting with rake v13.

Sneakers seems not to be maintained anymore, and this rake version limit is not being address properly so far. After we unblock this from here, I will use a pre-release for sneakers in web so we can make it work with rake v13.

More discussion https://github.com/jondot/sneakers/issues/452#issuecomment-878301702 and in other issues in the same repo.